### PR TITLE
feat: handle prisma migrations from the auth service

### DIFF
--- a/prisma/migrations/20250616171744_unify_migrations/migration.sql
+++ b/prisma/migrations/20250616171744_unify_migrations/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "Document" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "s3Key" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Document_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Document_userId_idx" ON "Document"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,4 +21,19 @@ model User {
   auth0Id   String   @unique
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  documents Document[]
+}
+
+model Document {
+  id         String   @id @default(uuid())
+  userId     String
+  user       User     @relation(fields: [userId], references: [id])
+  name       String
+  type       String
+  status     String   @default("active")
+  s3Key      String
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@index([userId])
 }


### PR DESCRIPTION
 This PR unifies Prisma migrations across all microservices, utilizing a single file.